### PR TITLE
Feature: Organize Firestore-related classes into firestore package

### DIFF
--- a/app/src/main/java/com/artemklymenko/cards/di/AuthModule.kt
+++ b/app/src/main/java/com/artemklymenko/cards/di/AuthModule.kt
@@ -1,7 +1,7 @@
 package com.artemklymenko.cards.di
 
-import com.artemklymenko.cards.data.AuthRepository
-import com.artemklymenko.cards.data.AuthRepositoryImpl
+import com.artemklymenko.cards.firestore.repository.AuthRepository
+import com.artemklymenko.cards.firestore.repository.impl.AuthRepositoryImpl
 import com.google.firebase.auth.FirebaseAuth
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/artemklymenko/cards/firestore/model/Resource.kt
+++ b/app/src/main/java/com/artemklymenko/cards/firestore/model/Resource.kt
@@ -1,4 +1,4 @@
-package com.artemklymenko.cards.data
+package com.artemklymenko.cards.firestore.model
 
 sealed class Resource<out R>{
     data class Success<out R>(val result: R): Resource<R>()

--- a/app/src/main/java/com/artemklymenko/cards/firestore/repository/AuthRepository.kt
+++ b/app/src/main/java/com/artemklymenko/cards/firestore/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
-package com.artemklymenko.cards.data
+package com.artemklymenko.cards.firestore.repository
 
+import com.artemklymenko.cards.firestore.model.Resource
 import com.google.firebase.auth.FirebaseUser
 
 interface AuthRepository {

--- a/app/src/main/java/com/artemklymenko/cards/firestore/repository/impl/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/artemklymenko/cards/firestore/repository/impl/AuthRepositoryImpl.kt
@@ -1,6 +1,8 @@
-package com.artemklymenko.cards.data
+package com.artemklymenko.cards.firestore.repository.impl
 
-import com.artemklymenko.cards.data.utils.await
+import com.artemklymenko.cards.firestore.utils.await
+import com.artemklymenko.cards.firestore.model.Resource
+import com.artemklymenko.cards.firestore.repository.AuthRepository
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import javax.inject.Inject

--- a/app/src/main/java/com/artemklymenko/cards/firestore/utils/FirebaseUtils.kt
+++ b/app/src/main/java/com/artemklymenko/cards/firestore/utils/FirebaseUtils.kt
@@ -1,4 +1,4 @@
-package com.artemklymenko.cards.data.utils
+package com.artemklymenko.cards.firestore.utils
 
 import com.google.android.gms.tasks.Task
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/main/java/com/artemklymenko/cards/view/fragments/SignInFragment.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/fragments/SignInFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.artemklymenko.cards.R
-import com.artemklymenko.cards.data.Resource
+import com.artemklymenko.cards.firestore.model.Resource
 import com.artemklymenko.cards.databinding.FragmentSignInBinding
 import com.artemklymenko.cards.domain.validation.handleLoginValidation
 import com.artemklymenko.cards.notification.utils.setupNotificationsSwitch

--- a/app/src/main/java/com/artemklymenko/cards/view/fragments/SignUpFragment.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/fragments/SignUpFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.artemklymenko.cards.R
-import com.artemklymenko.cards.data.Resource
+import com.artemklymenko.cards.firestore.model.Resource
 import com.artemklymenko.cards.databinding.FragmentSignUpBinding
 import com.artemklymenko.cards.domain.validation.handleRegisterValidation
 import com.artemklymenko.cards.vm.LoginViewModel

--- a/app/src/main/java/com/artemklymenko/cards/vm/LoginViewModel.kt
+++ b/app/src/main/java/com/artemklymenko/cards/vm/LoginViewModel.kt
@@ -2,8 +2,8 @@ package com.artemklymenko.cards.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.artemklymenko.cards.data.AuthRepository
-import com.artemklymenko.cards.data.Resource
+import com.artemklymenko.cards.firestore.repository.AuthRepository
+import com.artemklymenko.cards.firestore.model.Resource
 import com.google.firebase.auth.FirebaseUser
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow


### PR DESCRIPTION
- Moved "Resource", "AuthRepository", "AuthRepositoryImpl", and "FirebaseUtils" to the "firestore" package for better organization and consistency.
- Updated "AuthModule" imports to reflect the new package locations.
- Updated imports in all affected files to use the "firestore" package instead of the `data` package.