### PR TITLE
Fix: set tvModel text to null on error

### DIFF
--- a/app/src/main/java/com/artemklymenko/cards/view/activities/AddWordsActivity.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/activities/AddWordsActivity.kt
@@ -168,6 +168,7 @@ class AddWordsActivity : AppCompatActivity() {
             translateBtn.isEnabled =
                 sourceLang.text!!.isNotEmpty() && targetLang.text!!.isNotEmpty()
         }, { e ->
+            binding.tvModel.text = null
             Log.e(TAG, "startTranslation: ${e.printStackTrace()}")
             Toast.makeText(this, getString(R.string.failed_to_perform_automatic_translation), Toast.LENGTH_SHORT).show()
         })


### PR DESCRIPTION
Updated binding.tvModel.text to null in case of an error