### PR TITLE
fix: correct string "home" for de, uk, and ru languages

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">Cards</string>
     <string name="cards">Karten</string>
-    <string name="home">Homepage</string>
+    <string name="home">Startseite</string>
     <string name="settings">Einstellungen</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="start">Start</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">Cards</string>
     <string name="cards">Карточки</string>
-    <string name="home">Домой</string>
+    <string name="home">Главная</string>
     <string name="settings">Настройки</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="start">Начать</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">Cards</string>
     <string name="cards">Картки</string>
-    <string name="home">Дім</string>
+    <string name="home">Головна</string>
     <string name="settings">Налаштування</string>
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="start">Почати</string>


### PR DESCRIPTION
Updated the translation of "home" in German (de), Ukrainian (uk), and Russian (ru) language files