### PR TITLE
Refactor lifecycle handling in activities and fragments

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,7 +20,8 @@
         tools:targetApi="31">
         <activity
             android:name=".view.activities.CardsActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".view.activities.UpdateWordsActivity"
             android:exported="false" />

--- a/app/src/main/java/com/artemklymenko/cards/view/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/fragments/HomeFragment.kt
@@ -24,21 +24,25 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        val dataStorePreferenceManager = DataStorePreferenceManager.getInstance(container!!.context)
-        binding.apply {
-            btnAddWord.setOnClickListener {
-                startActivity(Intent(context, AddWordsActivity::class.java))
-            }
-            btnStartLearning.setOnClickListener {
-                startActivity(Intent(context, CardsActivity::class.java))
-            }
-            lifecycleScope.launch {
-                dataStorePreferenceManager.consecutiveDaysFlow.collect { consecutiveDays ->
-                    tvDays.text = consecutiveDays.toString()
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+            val dataStorePreferenceManager = DataStorePreferenceManager.getInstance(requireContext())
+            binding.apply {
+                btnAddWord.setOnClickListener {
+                    startActivity(Intent(context, AddWordsActivity::class.java))
+                }
+                btnStartLearning.setOnClickListener {
+                    startActivity(Intent(context, CardsActivity::class.java))
+                }
+                lifecycleScope.launch {
+                    dataStorePreferenceManager.consecutiveDaysFlow.collect { consecutiveDays ->
+                        tvDays.text = consecutiveDays.toString()
+                    }
                 }
             }
-        }
-        return binding.root
     }
     companion object {
         @JvmStatic

--- a/app/src/main/java/com/artemklymenko/cards/view/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/fragments/SettingsFragment.kt
@@ -25,14 +25,19 @@ class SettingsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSettingsBinding.inflate(inflater, container, false)
-        val dataStorePreferenceManager = DataStorePreferenceManager.getInstance(container!!.context)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val dataStorePreferenceManager = DataStorePreferenceManager.getInstance(requireContext())
         binding.switchNotification.isChecked = dataStorePreferenceManager.notice
 
         if (viewModel.currentUser?.email != null) {
             binding.tvUserEmail.text = viewModel.currentUser!!.email
         } else {
             binding.tvUserEmail.text = getString(R.string.user)
-            }
+        }
 
         binding.ivLogOut.setOnClickListener {
             viewModel.logout()
@@ -43,11 +48,9 @@ class SettingsFragment : Fragment() {
             setupNotificationsSwitch(
                 dataStorePreferenceManager,
                 isChecked,
-                container.context
+                requireContext()
             )
         }
-
-        return binding.root
     }
 
     private fun switchToSignInFragment() {

--- a/app/src/main/java/com/artemklymenko/cards/view/fragments/SignInFragment.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/fragments/SignInFragment.kt
@@ -28,26 +28,26 @@ class SignInFragment : Fragment() {
     private lateinit var viewModel: LoginViewModel
     private var loginFlow: StateFlow<Resource<FirebaseUser>?>? = null
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProvider(requireActivity())[LoginViewModel::class.java]
-        loginFlow = viewModel.loginFlow
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSignInBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
-        val dataStorePreferenceManager = DataStorePreferenceManager.getInstance(container!!.context)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val dataStorePreferenceManager = DataStorePreferenceManager.getInstance(requireContext())
+        viewModel = ViewModelProvider(requireActivity())[LoginViewModel::class.java]
+        loginFlow = viewModel.loginFlow
         binding.switchNotification.isChecked = dataStorePreferenceManager.notice
 
         binding.switchNotification.setOnCheckedChangeListener { _, isChecked ->
             setupNotificationsSwitch(
                 dataStorePreferenceManager,
                 isChecked,
-                container.context
+                requireContext()
             )
         }
 
@@ -58,7 +58,6 @@ class SignInFragment : Fragment() {
         binding.btnRegistration.setOnClickListener {
             loginFirebase()
         }
-        return binding.root
     }
 
     private fun loginFirebase() {

--- a/app/src/main/java/com/artemklymenko/cards/view/fragments/SignUpFragment.kt
+++ b/app/src/main/java/com/artemklymenko/cards/view/fragments/SignUpFragment.kt
@@ -26,17 +26,18 @@ class SignUpFragment : Fragment() {
     private lateinit var viewModel: LoginViewModel
     private var signupFlow: StateFlow<Resource<FirebaseUser>?>? = null
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProvider(requireActivity())[LoginViewModel::class.java]
-        signupFlow = viewModel.signupFlow
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSignUpBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(requireActivity())[LoginViewModel::class.java]
+        signupFlow = viewModel.signupFlow
 
         binding.btnSignIn.setOnClickListener {
             switchBackToSignInFragment()
@@ -52,7 +53,6 @@ class SignUpFragment : Fragment() {
                 }
             }
         }
-        return binding.root
     }
 
     private fun signUpFirebase() {


### PR DESCRIPTION
Enforced portrait orientation for CardsActivity to maintain a consistent user experience.
Moved view-related logic to onViewCreated in fragments to ensure null-safety and proper lifecycle handling.
Relocated data persistence logic from onCreate to onPause in CardsActivity for better alignment with the activity lifecycle.